### PR TITLE
Remove current base fee from lowGasPriceOldTypes environment

### DIFF
--- a/GeneralStateTests/stEIP1559/lowGasPriceOldTypes.json
+++ b/GeneralStateTests/stEIP1559/lowGasPriceOldTypes.json
@@ -15,7 +15,6 @@
             "currentGasLimit": "0xff112233445566",
             "currentNumber": "0x1",
             "currentTimestamp": "0x3e8",
-            "currentBaseFee": "0x3e8",
             "previousHash": "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
         },
         "pre": {


### PR DESCRIPTION
This is because, with `currentBaseFee` in the environment, an EIP-1559 transaction is (could be?) implied